### PR TITLE
Change alpha channel to non-transparent

### DIFF
--- a/microbit-blink/main.go
+++ b/microbit-blink/main.go
@@ -21,7 +21,7 @@ func main() {
 	deltaX := int16(1)
 	deltaY := int16(1)
 	then := time.Now()
-	c := color.RGBA{255, 255, 255, 255}
+	c := color.RGBA{255, 255, 255, 0}
 
 	for {
 		if time.Since(then).Nanoseconds() > 80000000 {

--- a/microbit-pixelbuttons/main.go
+++ b/microbit-pixelbuttons/main.go
@@ -23,7 +23,7 @@ func main() {
 	var (
 		x int16 = 2
 		y int16 = 2
-		c       = color.RGBA{255, 255, 255, 255}
+		c       = color.RGBA{255, 255, 255, 0}
 	)
 
 	then := time.Now()


### PR DESCRIPTION
With the change introduced in https://github.com/tinygo-org/drivers/pull/472 the alpha channel of the color used with the microbitmatrix is no longer ignored. For a pixel to light in full brightness, the alpha channel needs to be set to 0 (no transparency = full brightness).